### PR TITLE
Adding a simple default DNS query resolver

### DIFF
--- a/src/main/java/io/gingersnapproject/cdc/configuration/Configuration.java
+++ b/src/main/java/io/gingersnapproject/cdc/configuration/Configuration.java
@@ -3,10 +3,14 @@ package io.gingersnapproject.cdc.configuration;
 import java.util.Map;
 
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 
 @ConfigMapping(prefix = "gingersnap")
 public interface Configuration {
+
+   @WithDefault("false")
+   boolean dynamicMembership();
 
    Database database();
 

--- a/src/main/java/io/gingersnapproject/cdc/event/Events.java
+++ b/src/main/java/io/gingersnapproject/cdc/event/Events.java
@@ -1,5 +1,7 @@
 package io.gingersnapproject.cdc.event;
 
+import java.net.URI;
+
 import io.gingersnapproject.cdc.connector.DatabaseProvider;
 
 public class Events {
@@ -17,4 +19,8 @@ public class Events {
    public record ConnectorStartedEvent(String name, DatabaseProvider databaseProvider) { }
 
    public record ConnectorStoppedEvent(String name) { }
+
+   public record CacheMemberJoinEvent(URI uri) { }
+
+   public record CacheMemberLeaveEvent(URI uri) { }
 }

--- a/src/main/java/io/gingersnapproject/cdc/event/NotificationManager.java
+++ b/src/main/java/io/gingersnapproject/cdc/event/NotificationManager.java
@@ -1,5 +1,7 @@
 package io.gingersnapproject.cdc.event;
 
+import java.net.URI;
+
 import io.gingersnapproject.cdc.connector.DatabaseProvider;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -27,6 +29,9 @@ public class NotificationManager {
    @Inject Event<Events.BackendFailedEvent> backendFailedEvent;
    @Inject Event<Events.BackendStoppedEvent> backendStoppedEvent;
 
+   @Inject Event<Events.CacheMemberJoinEvent> memberJoinEvent;
+   @Inject Event<Events.CacheMemberLeaveEvent> memberLeaveEvent;
+
    public void connectorFailed(String name, Throwable t) {
       connectorFailedEvent.fire(new Events.ConnectorFailedEvent(name, t));
    }
@@ -49,5 +54,13 @@ public class NotificationManager {
 
    public void backendStoppedEvent(String name) {
       backendStoppedEvent.fire(new Events.BackendStoppedEvent(name));
+   }
+
+   public void memberJoinEvent(URI uri) {
+      memberJoinEvent.fire(new Events.CacheMemberJoinEvent(uri));
+   }
+
+   public void memberLeaveEvent(URI uri) {
+      memberLeaveEvent.fire(new Events.CacheMemberLeaveEvent(uri));
    }
 }

--- a/src/main/java/io/gingersnapproject/service/MembershipListener.java
+++ b/src/main/java/io/gingersnapproject/service/MembershipListener.java
@@ -1,0 +1,131 @@
+package io.gingersnapproject.service;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import io.gingersnapproject.cdc.ReschedulingTask;
+import io.gingersnapproject.cdc.configuration.Configuration;
+import io.gingersnapproject.cdc.event.NotificationManager;
+
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.infinispan.commons.util.concurrent.CompletableFutures;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ApplicationScoped
+public class MembershipListener {
+
+   private static final Logger log = LoggerFactory.getLogger(MembershipListener.class);
+   private static final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(r -> new Thread(r,"membership-listener"));
+
+   // Accessed by a single thread.
+   private final Set<InetAddress> members = new HashSet<>();
+   @Inject NotificationManager notificationManager;
+   @Inject Configuration configuration;
+
+   @ConfigProperty(name = "gingersnap.dynamic-membership", defaultValue = "false")
+   boolean dynamicMembership;
+
+   private ReschedulingTask<Void> task;
+   private volatile boolean shutdown;
+
+   void onStartup(@Observes StartupEvent ignore) {
+      if (task != null) return;
+
+      if (dynamicMembership) {
+         task = new ReschedulingTask<>(executor, this::pollDNSInformation, __ -> false, 15, TimeUnit.SECONDS, t -> {
+            log.debug("Poll DNS failure", t);
+            return true;
+         });
+         executor.submit(() -> {
+            task.schedule();
+         });
+      } else {
+         notificationManager.memberJoinEvent(configuration.cache().uri());
+      }
+   }
+
+   void onShutdown(@Observes ShutdownEvent ignore) {
+      if (task == null) return;
+
+      log.info("Shutdown membership listener");
+      task.close();
+      task = null;
+      shutdown = true;
+   }
+
+   // package-private for testing only.
+   CompletionStage<Void> pollDNSInformation() {
+      if (shutdown) return CompletableFutures.completedNull();
+
+      var uri = configuration.cache().uri();
+      Set<InetAddress> joiners = new HashSet<>(resolve(uri.getHost()));
+      Set<InetAddress> leavers = new HashSet<>(members);
+
+      leavers.removeIf(joiners::contains);
+      joiners.removeIf(members::contains);
+
+      members.removeAll(leavers);
+      members.addAll(joiners);
+
+      log.debug("Updating membership, joined '{}' and left '{}', current '{}'", joiners, leavers, members);
+      for (InetAddress leaver : leavers) {
+         notificationManager.memberLeaveEvent(asURI(uri, leaver));
+      }
+
+      for (InetAddress joiner : joiners) {
+         notificationManager.memberJoinEvent(asURI(uri, joiner));
+      }
+
+      return CompletableFutures.completedNull();
+   }
+
+   List<InetAddress> resolve(String query) {
+      try {
+         return Arrays.asList(InetAddress.getAllByName(query));
+      } catch (UnknownHostException e) {
+         log.error("Failed querying '{}'", query, e);
+         return Collections.emptyList();
+      }
+   }
+
+   private URI asURI(URI configured, InetAddress address) {
+      StringBuilder sb = new StringBuilder(configured.getScheme())
+            .append("://");
+
+      if (configured.getUserInfo() != null) {
+         sb.append(configured.getUserInfo())
+               .append("@");
+      }
+
+      sb.append(address.getHostAddress());
+
+      if (configured.getPort() > 0) {
+         sb.append(":")
+               .append(configured.getPort());
+      }
+
+      if (configured.getQuery() != null) {
+         sb.append("?")
+               .append(configured.getQuery());
+      }
+
+      return URI.create(sb.toString());
+   }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -63,3 +63,6 @@ quarkus.package.type=uber-jar
 ## Kubernetes Configuration
 gingersnap.k8s.rule-config-map=
 gingersnap.k8s.namespace=default
+
+# If enabled, poll the DNS records for membership changes.
+gingersnap.dynamic-membership=false

--- a/src/test/java/io/gingersnapproject/service/MembershipListenerTest.java
+++ b/src/test/java/io/gingersnapproject/service/MembershipListenerTest.java
@@ -1,0 +1,79 @@
+package io.gingersnapproject.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.util.HashSet;
+import java.util.List;
+
+import io.gingersnapproject.cdc.configuration.Cache;
+import io.gingersnapproject.cdc.configuration.Configuration;
+import io.gingersnapproject.cdc.event.NotificationManager;
+import io.gingersnapproject.util.Utils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class MembershipListenerTest {
+
+   private final Configuration configurationMock = mock(Configuration.class);
+   private final NotificationManager notificationMock = mock(NotificationManager.class);
+   private MembershipListener listener;
+
+   @BeforeEach
+   public void beforeEach() {
+      clearInvocations(configurationMock);
+      reset(configurationMock);
+
+      listener = new MembershipListener();
+      listener.configuration = configurationMock;
+      listener.notificationManager = notificationMock;
+   }
+
+
+   @Test
+   public void testMembershipOperations() throws Exception {
+      InetAddress m1 = InetAddress.getByName("10.0.0.10"),
+            m2 = InetAddress.getByName("10.0.0.11"),
+            m3 = InetAddress.getByName("10.0.0.12");
+      List<InetAddress> addresses = List.of(m1, m2, m3);
+
+      listener = spy(listener);
+
+      var cacheConf = mock(Cache.class);
+      when(cacheConf.uri()).thenReturn(URI.create("hotrod://admin:password@cache-manager:11222?sasl_mechanism=SCRAM-SHA-512"));
+      when(configurationMock.cache()).thenReturn(cacheConf);
+      when(listener.resolve("cache-manager")).thenReturn(addresses);
+
+      listener.pollDNSInformation();
+
+      // The members are added.
+      Assertions.assertEquals(new HashSet<>(addresses), Utils.extractField(MembershipListener.class, "members", listener));
+      verify(notificationMock, times(3)).memberJoinEvent(any());
+      verify(notificationMock, times(1)).memberJoinEvent(eq(URI.create("hotrod://admin:password@10.0.0.10:11222?sasl_mechanism=SCRAM-SHA-512")));
+
+      // Member m3 left.
+      addresses = List.of(m1, m2);
+      when(listener.resolve("cache-manager")).thenReturn(addresses);
+      listener.pollDNSInformation();
+      Assertions.assertEquals(new HashSet<>(addresses), Utils.extractField(MembershipListener.class, "members", listener));
+      verify(notificationMock, times(1)).memberLeaveEvent(eq(URI.create("hotrod://admin:password@10.0.0.12:11222?sasl_mechanism=SCRAM-SHA-512")));
+
+      // Member m3 joins again.
+      addresses = List.of(m1, m2, m3);
+      when(listener.resolve("cache-manager")).thenReturn(addresses);
+      listener.pollDNSInformation();
+      Assertions.assertEquals(new HashSet<>(addresses), Utils.extractField(MembershipListener.class, "members", listener));
+      verify(notificationMock, times(4)).memberJoinEvent(any());
+   }
+}


### PR DESCRIPTION
OK, the PR is as simple as it could be. It adds a service that receives a string and returns the list of addresses. This works using something in `/etc/hosts` and deploying a headless service in Kubernetes. But this is to start a discussion.

When running in Kubernetes, we might have multiple replicas, and the service will return the addresses of all pods:

```text
$ k get pods -n gingersnap
NAME                             READY   STATUS    RESTARTS   AGE
cache-manager-5869f7b9cb-542z5   1/1     Running   0          27s
cache-manager-5869f7b9cb-p2qcg   1/1     Running   0          27s
cache-manager-5869f7b9cb-z2jwv   1/1     Running   0          27s
db-syncer-6d6cf998d8-gm7cn       1/1     Running   0          27s
mysql-568447df7b-j4t6m           1/1     Running   0          27s
```

```text
$ k logs db-syncer-6d6cf998d8-gm7cn -n gingersnap
INFO exec  java -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+ExitOnOutOfMemoryError -cp "." -jar /deployments/db-syncer.jar
2023-01-19 13:25:01,980 INFO  [io.gin.cdc.ManagedEngine] (main) Starting service
FOUND ADDR => cache-manager/172.17.0.6
FOUND ADDR => cache-manager/172.17.0.9
FOUND ADDR => cache-manager/172.17.0.5
2023-01-19 13:25:02,003 INFO  [io.gin.k8s.CacheRuleInformer] (main) Kubernetes client not found, not watching config map
2023-01-19 13:25:02,055 INFO  [io.quarkus] (main) db-syncer 0.1-SNAPSHOT on JVM (powered by Quarkus 2.14.3.Final) started in 0.685s. Listening on: http://0.0.0.0:8080
2023-01-19 13:25:02,055 INFO  [io.quarkus] (main) Profile prod activated.
2023-01-19 13:25:02,055 INFO  [io.quarkus] (main) Installed features: [cdi, kubernetes-client, micrometer, resteasy-reactive, smallrye-context-propagation, smallrye-health, vertex]
```

We now have multiple `RemoteCacheManager`, one for each pod. Keeping in mind that we want to add dynamic membership, some pods can join and leave at any time. We have an issue with how to maintain all these caches.

If pods can arrive at any time, we have to create a new Debezium engine to start consuming events from the very start, otherwise, the pod might miss some data. As a side-effect, each pod might have a different offset and, therefore, different contents in the cache.
 
The approach I have in mind is similar to how we handle multiple rules. Each pod can fail independently, meaning that backoff and error handling is independent, too. And each pod would be able to proceed at its own pace. No tying all pods from a rule together.

I would like to get feedback before starting a change like that. [This](https://github.com/jabolina/gingersnap-k8s) is the setup I was running in Kubernetes.