### PR TITLE
Reworking informers and adding pod informer

### DIFF
--- a/src/main/java/io/gingersnapproject/k8s/CacheInformerManager.java
+++ b/src/main/java/io/gingersnapproject/k8s/CacheInformerManager.java
@@ -1,0 +1,59 @@
+package io.gingersnapproject.k8s;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import io.gingersnapproject.k8s.informer.KubernetesInformer;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
+import io.quarkus.arc.All;
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ApplicationScoped
+public class CacheInformerManager {
+
+   private static final Logger log = LoggerFactory.getLogger(CacheInformerManager.class);
+
+   @Inject
+   Instance<KubernetesClient> client;
+
+   @All
+   @Inject
+   List<KubernetesInformer<?>> informers;
+
+   private final List<SharedIndexInformer<?>> runningInformers = new ArrayList<>();
+
+   void startWatching(@Observes StartupEvent ignore) {
+      if (client.isUnsatisfied()) {
+         log.info("Kubernetes client not found, not registering informers");
+         return;
+      }
+
+      KubernetesClient kc = client.get();
+      for (var informer : informers) {
+         var registered = informer.register(kc);
+         runningInformers.add(registered);
+         registered.start();
+      }
+   }
+
+   public void stop(@Observes ShutdownEvent ignore) {
+      log.info("De-registering informers");
+
+      var iterator = runningInformers.iterator();
+      while (iterator.hasNext()) {
+         iterator.next().stop();
+         iterator.remove();
+      }
+   }
+
+}

--- a/src/main/java/io/gingersnapproject/k8s/informer/KubernetesInformer.java
+++ b/src/main/java/io/gingersnapproject/k8s/informer/KubernetesInformer.java
@@ -1,0 +1,10 @@
+package io.gingersnapproject.k8s.informer;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
+import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
+
+public interface KubernetesInformer<T> extends ResourceEventHandler<T> {
+
+   SharedIndexInformer<T> register(KubernetesClient kc);
+}

--- a/src/main/java/io/gingersnapproject/k8s/informer/PodInformer.java
+++ b/src/main/java/io/gingersnapproject/k8s/informer/PodInformer.java
@@ -1,0 +1,49 @@
+package io.gingersnapproject.k8s.informer;
+
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ApplicationScoped
+public class PodInformer implements KubernetesInformer<Pod> {
+   private static final Logger log = LoggerFactory.getLogger(PodInformer.class);
+   private static final Set<String> VALID_HR_IMAGES = Set.of(
+         "quay.io/gingersnap/cache-manager",
+         "infinispan/server"
+   );
+
+   @Override
+   public SharedIndexInformer<Pod> register(KubernetesClient kc) {
+      return kc.pods().inform(this, 30 * 1000);
+   }
+
+   @Override
+   public void onAdd(Pod obj) {
+      if (isHotRodPod(obj)) log.info("Adding HR pod {}", obj);
+   }
+
+   @Override
+   public void onUpdate(Pod oldObj, Pod newObj) { }
+
+   @Override
+   public void onDelete(Pod obj, boolean deletedFinalStateUnknown) {
+      if (isHotRodPod(obj)) log.info("Removing HR pod {}", obj);
+   }
+
+   private static boolean isHotRodPod(Pod obj) {
+      for (var container : obj.getSpec().getContainers()) {
+         for (var validImage : VALID_HR_IMAGES) {
+            if (container.getImage().startsWith(validImage))
+               return true;
+         }
+      }
+
+      return false;
+   }
+}

--- a/src/test/java/io/gingersnapproject/k8s/ConfigMapEventHandlerTest.java
+++ b/src/test/java/io/gingersnapproject/k8s/ConfigMapEventHandlerTest.java
@@ -19,18 +19,19 @@ import com.google.protobuf.util.JsonFormat;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.gingersnapproject.cdc.DynamicRuleManagement;
 import io.gingersnapproject.cdc.configuration.Rule;
+import io.gingersnapproject.k8s.informer.ConfigMapInformer;
 import io.gingersnapproject.proto.JSONMappingTest;
 import io.gingersnapproject.proto.api.config.v1alpha1.EagerCacheRuleSpec;
 
 public class ConfigMapEventHandlerTest {
 
-    static ConfigMapEventHandler cmeh;
+    static ConfigMapInformer cmeh;
     static DynamicRuleManagement drmMock;
 
     @BeforeAll
     public static void setup() {
         drmMock = Mockito.mock(DynamicRuleManagement.class);
-        cmeh = new ConfigMapEventHandler(drmMock);
+        cmeh = new ConfigMapInformer(drmMock);
     }
 
     @BeforeEach
@@ -126,7 +127,7 @@ public class ConfigMapEventHandlerTest {
 
 }
 
-class EagerCacheRuleSpecAdapterForTest  extends EagerCacheRuleSpecAdapter {
+class EagerCacheRuleSpecAdapterForTest  extends ConfigMapInformer.EagerCacheRuleSpecAdapter {
     public EagerCacheRuleSpecAdapterForTest(EagerCacheRuleSpec eagerRule) {
         super(eagerRule);
     }


### PR DESCRIPTION
Besides adding the pod informer, this one is also moving some stuff around, although it's just copy-paste. The thing here is that now we can listen for pods with the specified images. Right now I didn't add the logic to actually add/remove the pods.

In another approach, we could use labels to identify the pods