### PR TITLE
Cache backend can join and leave

### DIFF
--- a/src/main/java/io/gingersnapproject/cdc/ManagedEngine.java
+++ b/src/main/java/io/gingersnapproject/cdc/ManagedEngine.java
@@ -1,46 +1,55 @@
 package io.gingersnapproject.cdc;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import io.gingersnapproject.cdc.cache.CacheIdentifier;
 import io.gingersnapproject.cdc.cache.CacheService;
 import io.gingersnapproject.cdc.configuration.Configuration;
 import io.gingersnapproject.cdc.configuration.Rule;
 import io.gingersnapproject.cdc.event.Events;
 import io.gingersnapproject.cdc.event.NotificationManager;
+import io.gingersnapproject.cdc.util.AggregateCompletionStage;
+import io.gingersnapproject.cdc.util.CompletionStages;
+
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
+import org.infinispan.commons.util.concurrent.CompletableFutures;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @ApplicationScoped
 public class ManagedEngine implements DynamicRuleManagement {
    private static final Logger log = LoggerFactory.getLogger(ManagedEngine.class);
    private static final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(r ->
          new Thread(r, "scheduled-engine-error-handler"));
-   private final Map<String, StartStopEngine> engines = new ConcurrentHashMap<>();
+   private final Map<CacheIdentifier, StartStopEngine> engines = new ConcurrentHashMap<>();
+   private final Map<String, Rule> knownRules = new ConcurrentHashMap<>();
+   private final Set<URI> knownMembers = ConcurrentHashMap.newKeySet();
 
    @Inject Configuration config;
 
-   @Inject  CacheService cacheService;
+   @Inject CacheService cacheService;
 
    @Inject NotificationManager eventing;
 
    public void start(@Observes StartupEvent ignore) {
       log.info("Starting service");
-      for (Map.Entry<String, Rule> entry : config.rules().entrySet()) {
-         addRule(entry.getKey(), entry.getValue());
-      }
+      knownRules.putAll(config.rules());
+      addRuleWithKnownMembers();
    }
 
    void stop(@Observes ShutdownEvent ignore) {
@@ -55,38 +64,39 @@ public class ManagedEngine implements DynamicRuleManagement {
       }
    }
 
+   void memberJoined(@Observes Events.CacheMemberJoinEvent ev) {
+      log.info("New member joined {}", ev);
+      if (knownMembers.add(ev.uri())) addRuleWithKnownMembers();
+   }
+
+   void memberLeft(@Observes Events.CacheMemberLeaveEvent ev) {
+      log.info("Member left {}", ev);
+      if (!knownMembers.remove(ev.uri())) return;
+      remove(identifier ->  identifier.uri().equals(ev.uri()));
+   }
+
    void engineFailed(@Observes Events.ConnectorFailedEvent ev) {
-       engineError(ev.name());
+       engineError(ev.identifier());
    }
 
    void backendFailed(@Observes Events.BackendFailedEvent ev) {
-      engineError(ev.name());
+      engineError(ev.identifier());
    }
 
-   public void engineError(String name) {
-      StartStopEngine sse = engines.get(name);
+   private void engineError(CacheIdentifier identifier) {
+      StartStopEngine sse = engines.get(identifier);
       // Try to mark stop pending, only first caller should submit task
       if (sse == null || !sse.attemptMarkStopping()) {
          return;
       }
       // Have to submit on a different thread to not block the debezium poll loop
-      scheduledExecutorService.submit(((() -> {
-            stopEngine(sse, name);
-            log.info("Scheduling retry for engine {}", name);
-            ReschedulingTask<Boolean> reschedulingTask = new ReschedulingTask<>(scheduledExecutorService, sse.engine::cacheServiceAvailable,
-                  available -> {
-                     if (available) {
-                        sse.start();
-                     }
-                     return !available;
-                  }, 10, TimeUnit.SECONDS,
-                  t -> {
-                     log.trace("Retry task encountered error for engine {}, rescheduling attempt again later", name, t);
-                     return true;
-                  });
-            sse.markRetrying(reschedulingTask.schedule());
-         }
-      )));
+      scheduledExecutorService.submit(() -> {
+         stopEngine(sse, sse.engine.getName());
+         log.info("Scheduling retry for engine {}", identifier);
+
+         // Executor has a single thread, do not join the completable.
+         retryEngineStart(identifier, sse);
+      });
    }
 
    private static void stopEngine(StartStopEngine engine, String name) {
@@ -99,25 +109,86 @@ public class ManagedEngine implements DynamicRuleManagement {
       }
    }
 
+   private static void shutdownEngine(StartStopEngine engine, String name) {
+      try {
+         engine.shutdown();
+      } catch (IOException e) {
+         log.error("Failed engine {} shutdown", name, e);
+         throw new RuntimeException(e);
+      }
+   }
+
    @Override
    public void addRule(String name, Rule rule) {
-      StartStopEngine sse = engines.computeIfAbsent(name, ignore ->
-            new StartStopEngine(new EngineWrapper(name, config, rule, cacheService, eventing))
-      );
-      sse.start();
+      knownRules.put(name, rule);
+      addRuleWithKnownMembers();
+   }
+
+   private void addRuleWithKnownMembers() {
+      AggregateCompletionStage<Void> stage = CompletionStages.aggregateCompletionStage();
+      for (Map.Entry<String, Rule> rule : knownRules.entrySet()) {
+         for (URI memberURI : knownMembers) {
+            var identifier = CacheIdentifier.of(rule.getKey(), memberURI);
+            engines.computeIfAbsent(identifier, ignore -> {
+               log.info("Creating new engine for {}", identifier);
+               var sse = new StartStopEngine(new EngineWrapper(identifier, config, rule.getValue(), cacheService, eventing));
+               stage.dependsOn(startEngine(identifier, sse));
+               return sse;
+            });
+         }
+      }
+   }
+
+   private CompletionStage<Void> startEngine(CacheIdentifier identifier, StartStopEngine sse) {
+      try {
+         sse.start();
+         return CompletableFutures.completedNull();
+      } catch (Exception e) {
+         log.error("Failed directly starting engine {}, retrying", identifier, e);
+         return retryEngineStart(identifier, sse);
+      }
+   }
+
+   private CompletionStage<Void> retryEngineStart(CacheIdentifier identifier, StartStopEngine sse) {
+      CompletableFuture<Void> cf = new CompletableFuture<>();
+      ReschedulingTask<Boolean> reschedulingTask = new ReschedulingTask<>(scheduledExecutorService,
+            () -> {
+               try {
+                  sse.start();
+                  return CompletableFutures.completedTrue();
+               } catch (IOException e) {
+                  return CompletableFuture.failedFuture(e);
+               }
+            },
+            ignore -> {
+               log.info("Engine {} now started", identifier);
+               cf.complete(null);
+               return true;
+            }, 10, TimeUnit.SECONDS,
+            t -> {
+               log.error("Retry task encountered error for engine {}, rescheduling attempt again later", identifier, t);
+               return true;
+            });
+      sse.markRetrying(reschedulingTask.schedule());
+      return cf;
    }
 
    @Override
    public void removeRule(String name) {
-       engines.computeIfPresent(name, (ignore, sse) -> {
-          try {
-             sse.shutdown();
-          } catch (IOException e) {
-             log.error("Failed engine {} shutdown", name, e);
-             throw new RuntimeException(e);
-          }
-          return null;
-       });
+      if (knownRules.remove(name) == null) return;
+      remove(identifier -> identifier.rule().equals(name));
+   }
+
+   private void remove(Predicate<CacheIdentifier> predicate) {
+      for (var it = engines.entrySet().iterator(); it.hasNext();) {
+         var entry = it.next();
+         CacheIdentifier identifier = entry.getKey();
+         if (predicate.test(identifier)) {
+            StartStopEngine engine = entry.getValue();
+            shutdownEngine(engine, engine.engine.getName());
+            it.remove();
+         }
+      }
    }
 
    // Accessible during tests.
@@ -139,7 +210,7 @@ public class ManagedEngine implements DynamicRuleManagement {
          this.engine = engine;
       }
 
-      public synchronized void start() {
+      public synchronized void start() throws IOException {
          switch (status) {
             case RUNNING, SHUTDOWN -> throw new IllegalArgumentException(
                   "Engine " + engine.getName() + " cannot be started, state was " + status);

--- a/src/main/java/io/gingersnapproject/cdc/cache/CacheIdentifier.java
+++ b/src/main/java/io/gingersnapproject/cdc/cache/CacheIdentifier.java
@@ -7,4 +7,9 @@ public record CacheIdentifier(String rule, URI uri) {
    public static CacheIdentifier of(String rule, URI uri) {
       return new CacheIdentifier(rule, uri);
    }
+
+   @Override
+   public String toString() {
+      return String.format("%s-%s", rule, uri.getHost());
+   }
 }

--- a/src/main/java/io/gingersnapproject/cdc/cache/CacheService.java
+++ b/src/main/java/io/gingersnapproject/cdc/cache/CacheService.java
@@ -1,7 +1,7 @@
 package io.gingersnapproject.cdc.cache;
 
+import java.io.IOException;
 import java.net.URI;
-import java.util.concurrent.CompletionStage;
 
 import io.gingersnapproject.cdc.CacheBackend;
 import io.gingersnapproject.cdc.OffsetBackend;
@@ -9,11 +9,10 @@ import io.gingersnapproject.cdc.SchemaBackend;
 import io.gingersnapproject.cdc.configuration.Rule;
 
 public interface CacheService {
-   CompletionStage<Boolean> reconnect(CacheIdentifier identifier, Rule rule);
 
    void stop(CacheIdentifier identifier);
 
-   CacheBackend backendForRule(CacheIdentifier identifier, Rule rule);
+   CacheBackend start(CacheIdentifier identifier, Rule rule) throws IOException;
 
    OffsetBackend offsetBackend(URI managerURI);
 

--- a/src/main/java/io/gingersnapproject/cdc/event/Events.java
+++ b/src/main/java/io/gingersnapproject/cdc/event/Events.java
@@ -2,23 +2,24 @@ package io.gingersnapproject.cdc.event;
 
 import java.net.URI;
 
+import io.gingersnapproject.cdc.cache.CacheIdentifier;
 import io.gingersnapproject.cdc.connector.DatabaseProvider;
 
 public class Events {
 
    private Events() { }
 
-   public record BackendFailedEvent(String name, Throwable throwable) { }
+   public record BackendFailedEvent(CacheIdentifier identifier, Throwable throwable) { }
 
-   public record BackendStartedEvent(String name, boolean reconnect) { }
+   public record BackendStartedEvent(CacheIdentifier identifier, boolean reconnect) { }
 
-   public record BackendStoppedEvent(String name) { }
+   public record BackendStoppedEvent(CacheIdentifier identifier) { }
 
-   public record ConnectorFailedEvent(String name, Throwable throwable) { }
+   public record ConnectorFailedEvent(CacheIdentifier identifier, Throwable throwable) { }
 
-   public record ConnectorStartedEvent(String name, DatabaseProvider databaseProvider) { }
+   public record ConnectorStartedEvent(CacheIdentifier identifier, DatabaseProvider databaseProvider) { }
 
-   public record ConnectorStoppedEvent(String name) { }
+   public record ConnectorStoppedEvent(CacheIdentifier identifier) { }
 
    public record CacheMemberJoinEvent(URI uri) { }
 

--- a/src/main/java/io/gingersnapproject/cdc/event/NotificationManager.java
+++ b/src/main/java/io/gingersnapproject/cdc/event/NotificationManager.java
@@ -2,6 +2,7 @@ package io.gingersnapproject.cdc.event;
 
 import java.net.URI;
 
+import io.gingersnapproject.cdc.cache.CacheIdentifier;
 import io.gingersnapproject.cdc.connector.DatabaseProvider;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -32,28 +33,28 @@ public class NotificationManager {
    @Inject Event<Events.CacheMemberJoinEvent> memberJoinEvent;
    @Inject Event<Events.CacheMemberLeaveEvent> memberLeaveEvent;
 
-   public void connectorFailed(String name, Throwable t) {
-      connectorFailedEvent.fire(new Events.ConnectorFailedEvent(name, t));
+   public void connectorFailed(CacheIdentifier identifier, Throwable t) {
+      connectorFailedEvent.fire(new Events.ConnectorFailedEvent(identifier, t));
    }
 
-   public void connectorStarted(String name, DatabaseProvider provider) {
-      connectorStartedEvent.fire(new Events.ConnectorStartedEvent(name, provider));
+   public void connectorStarted(CacheIdentifier identifier, DatabaseProvider provider) {
+      connectorStartedEvent.fire(new Events.ConnectorStartedEvent(identifier, provider));
    }
 
-   public void connectorStopped(String name) {
-      connectorStoppedEvent.fire(new Events.ConnectorStoppedEvent(name));
+   public void connectorStopped(CacheIdentifier identifier) {
+      connectorStoppedEvent.fire(new Events.ConnectorStoppedEvent(identifier));
    }
 
-   public void backendStartedEvent(String name, boolean reconnect) {
-      backendStartedEvent.fire(new Events.BackendStartedEvent(name, reconnect));
+   public void backendStartedEvent(CacheIdentifier identifier, boolean reconnect) {
+      backendStartedEvent.fire(new Events.BackendStartedEvent(identifier, reconnect));
    }
 
-   public void backendFailedEvent(String name, Throwable throwable) {
-      backendFailedEvent.fire(new Events.BackendFailedEvent(name, throwable));
+   public void backendFailedEvent(CacheIdentifier identifier, Throwable throwable) {
+      backendFailedEvent.fire(new Events.BackendFailedEvent(identifier, throwable));
    }
 
-   public void backendStoppedEvent(String name) {
-      backendStoppedEvent.fire(new Events.BackendStoppedEvent(name));
+   public void backendStoppedEvent(CacheIdentifier identifier) {
+      backendStoppedEvent.fire(new Events.BackendStoppedEvent(identifier));
    }
 
    public void memberJoinEvent(URI uri) {

--- a/src/main/java/io/gingersnapproject/health/ConnectorReadiness.java
+++ b/src/main/java/io/gingersnapproject/health/ConnectorReadiness.java
@@ -16,18 +16,18 @@ public class ConnectorReadiness extends AbstractHealthChecker<String> {
    private static final String CONNECTOR_HEALTH = "Connector health";
 
    void engineStarted(@Observes Events.ConnectorStartedEvent ev) {
-      log.info("Engine {} started", ev.name());
-      isUp(ev.name());
+      log.info("Engine {} started", ev.identifier());
+      isUp(ev.identifier().toString());
    }
 
    void engineStopped(@Observes Events.ConnectorStoppedEvent ev) {
-      log.info("Engine {} stopped", ev.name());
-      isDone(ev.name());
+      log.info("Engine {} stopped", ev.identifier());
+      isDone(ev.identifier().toString());
    }
 
    void engineFailed(@Observes Events.ConnectorFailedEvent ev) {
-      log.error("Engine {} failed", ev.name(), ev.throwable());
-      isDown(ev.name());
+      log.error("Engine {} failed", ev.identifier(), ev.throwable());
+      isDown(ev.identifier().toString());
    }
 
    @Override

--- a/src/main/java/io/gingersnapproject/metrics/micrometer/MicrometerMetrics.java
+++ b/src/main/java/io/gingersnapproject/metrics/micrometer/MicrometerMetrics.java
@@ -51,7 +51,7 @@ public class MicrometerMetrics implements DBSyncerMetrics {
    }
 
    void registerMetrics(@Observes Events.ConnectorStartedEvent ev) {
-      String rule = ev.name();
+      String rule = ev.identifier().toString();
       DatabaseProvider db = ev.databaseProvider();
       log.info("Registering metrics for {}", rule);
       if (mBeanServer == null) {
@@ -67,8 +67,8 @@ public class MicrometerMetrics implements DBSyncerMetrics {
    }
 
    void unregisterMetrics(@Observes Events.ConnectorStoppedEvent ev) {
-      log.info("Unregistering metrics for {}", ev.name());
-      rulesMetric.computeIfPresent(ev.name(), (ruleName, ruleMetrics) -> {
+      log.info("Unregistering metrics for {}", ev.identifier());
+      rulesMetric.computeIfPresent(ev.identifier().toString(), (ruleName, ruleMetrics) -> {
          ruleMetrics.ids().forEach(registry::remove);
          return null;
       });

--- a/src/test/java/io/gingersnapproject/cdc/MultiCacheManagerTest.java
+++ b/src/test/java/io/gingersnapproject/cdc/MultiCacheManagerTest.java
@@ -1,0 +1,182 @@
+package io.gingersnapproject.cdc;
+
+import static io.gingersnapproject.util.Utils.eventually;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import io.gingersnapproject.cdc.cache.CacheIdentifier;
+import io.gingersnapproject.cdc.cache.CacheService;
+import io.gingersnapproject.cdc.configuration.Rule;
+import io.gingersnapproject.cdc.event.Events;
+import io.gingersnapproject.cdc.event.NotificationManager;
+import io.gingersnapproject.testcontainers.annotation.WithDatabase;
+import io.gingersnapproject.util.ArcUtil;
+import io.gingersnapproject.util.ByRef;
+import io.gingersnapproject.util.Utils;
+
+import io.quarkus.test.junit.QuarkusMock;
+import io.quarkus.test.junit.QuarkusTest;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@WithDatabase(rules = MultiCacheManagerTest.RULE_NAME)
+public class MultiCacheManagerTest {
+   static final String RULE_NAME = "multimanager";
+
+   private static final NotificationManager notification = mock(NotificationManager.class);
+
+   @Inject ManagedEngine manager;
+   @ConfigProperty(name = "gingersnap.cache.uri") URI hotRodURI;
+
+   @BeforeAll
+   static void beforeAll() {
+      QuarkusMock.installMockForType(notification, NotificationManager.class);
+   }
+
+   @BeforeEach
+   void beforeEach() {
+      clearInvocations(notification);
+      reset(notification);
+   }
+
+   @Test
+   public void testLeaveAndReturn() throws Exception {
+      URI additionalMember = createAnotherHotRodURI();
+      var additionalId = CacheIdentifier.of(RULE_NAME, additionalMember);
+      manager.memberJoined(new Events.CacheMemberJoinEvent(additionalMember));
+
+      // Additional member backend started first time.
+      verify(notification, times(1)).backendStartedEvent(eq(additionalId), eq(false));
+      eventually(() -> "Additional member engine not started", () -> {
+         try {
+            verify(notification, times(1)).connectorStarted(eq(additionalId), any());
+            return true;
+         } catch (Throwable ignore) {
+            return false;
+         }
+      }, 5, TimeUnit.SECONDS);
+
+      Set<URI> knownMembers = Utils.extractField(ManagedEngine.class, "knownMembers", manager);
+      assertEquals(2, knownMembers.size());
+
+      manager.memberLeft(new Events.CacheMemberLeaveEvent(additionalMember));
+      knownMembers = Utils.extractField(ManagedEngine.class, "knownMembers", manager);
+      assertEquals(1, knownMembers.size());
+      verify(notification, times(1)).connectorStopped(eq(additionalId));
+      verify(notification, times(1)).backendStoppedEvent(eq(additionalId));
+
+      // Join again, should remove from offline list and reconnect the engine.
+      manager.memberJoined(new Events.CacheMemberJoinEvent(additionalMember));
+
+      knownMembers = Utils.extractField(ManagedEngine.class, "knownMembers", manager);
+      assertEquals(2, knownMembers.size());
+
+      // Additional member backend restarted.
+      verify(notification, times(1)).backendStartedEvent(eq(additionalId), eq(true));
+
+      Map<CacheIdentifier, ManagedEngine.StartStopEngine> engines = Utils.extractField(ManagedEngine.class, "engines", manager);
+      assertEquals(2, engines.size());
+      assertTrue(engines.containsKey(additionalId));
+      for (CacheIdentifier identifier : engines.keySet()) {
+         assertTrue(identifier.uri().equals(hotRodURI) || identifier.uri().equals(additionalMember));
+      }
+
+      eventually(() -> "Additional member engine not started: " + additionalId, () -> {
+         try {
+            verify(notification, times(1)).connectorStarted(eq(additionalId), any());
+            return true;
+         } catch (Throwable ignore) {
+            return false;
+         }
+      }, 5, TimeUnit.SECONDS);
+      eventually(() -> "Engine not restarted!", () -> {
+         var engine = engines.get(additionalId);
+         ManagedEngine.Status status = Utils.extractField(engine, "status");
+         return status == ManagedEngine.Status.RUNNING;
+      }, 15, TimeUnit.SECONDS);
+      verify(notification, never()).connectorFailed(any(), any());
+   }
+
+   @Test
+   public void testRemovingRule() throws Exception {
+      URI additionalMember = createAnotherHotRodURI();
+
+      // An additional member joins, so we have 2 engines.
+      manager.memberJoined(new Events.CacheMemberJoinEvent(additionalMember));
+
+      manager.removeRule(RULE_NAME);
+
+      // Members are still known.
+      Set<URI> knownMembers = Utils.extractField(ManagedEngine.class, "knownMembers", manager);
+      assertEquals(2, knownMembers.size());
+
+      // We don't have any engine running and no registered rules.
+      Map<CacheIdentifier, ManagedEngine.StartStopEngine> engines = Utils.extractField(ManagedEngine.class, "engines", manager);
+      assertTrue(engines.isEmpty());
+
+      Map<CacheIdentifier, Rule> knownRules = Utils.extractField(ManagedEngine.class, "knownRules", manager);
+      assertTrue(knownRules.isEmpty());
+      verify(notification, never()).connectorFailed(any(), any());
+   }
+
+   @Test
+   public void testUnhealthyJoinerDoesNotBlockLeaving() throws Exception {
+      var throwable = new ByRef<Throwable>(new RuntimeException("Expected failure"));
+      Executor executor = Executors.newSingleThreadExecutor();
+      CacheService cacheService = ArcUtil.instance(CacheService.class);
+      CacheService mockCacheService = spy(cacheService);
+      QuarkusMock.installMockForInstance(mockCacheService, cacheService);
+      CountDownLatch latch = new CountDownLatch(1);
+      CacheIdentifier identifier = CacheIdentifier.of(RULE_NAME, createAnotherHotRodURI());
+
+      doAnswer(invocation -> {
+         if (throwable.ref() != null) throw throwable.ref();
+         return invocation.callRealMethod();
+      }).when(mockCacheService).start(eq(identifier), any());
+
+      // Flaky?
+      executor.execute(() -> manager.memberJoined(new Events.CacheMemberJoinEvent(identifier.uri())));
+      executor.execute(() -> {
+         manager.memberLeft(new Events.CacheMemberLeaveEvent(identifier.uri()));
+         latch.countDown();
+      });
+      assertTrue(latch.await(10, TimeUnit.SECONDS));
+      throwable.setRef(null);
+
+      Set<URI> knownMembers = Utils.extractField(ManagedEngine.class, "knownMembers", manager);
+      assertEquals(1, knownMembers.size());
+
+      Map<CacheIdentifier, ManagedEngine.StartStopEngine> engines = Utils.extractField(ManagedEngine.class, "engines", manager);
+      assertFalse(engines.containsKey(identifier));
+   }
+
+   private URI createAnotherHotRodURI() throws URISyntaxException {
+      return new URI("hotrod", hotRodURI.getUserInfo(), "127.0.0.1", hotRodURI.getPort(), hotRodURI.getPath(), hotRodURI.getQuery(), hotRodURI.getFragment());
+   }
+}
+

--- a/src/test/java/io/gingersnapproject/cdc/cache/hotrod/HotRodServiceTest.java
+++ b/src/test/java/io/gingersnapproject/cdc/cache/hotrod/HotRodServiceTest.java
@@ -1,0 +1,202 @@
+package io.gingersnapproject.cdc.cache.hotrod;
+
+import static io.gingersnapproject.util.Utils.eventually;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import io.gingersnapproject.cdc.cache.CacheIdentifier;
+import io.gingersnapproject.cdc.cache.CacheService;
+import io.gingersnapproject.cdc.configuration.Rule;
+import io.gingersnapproject.cdc.event.NotificationManager;
+import io.gingersnapproject.proto.api.config.v1alpha1.KeyFormat;
+import io.gingersnapproject.testcontainers.annotation.WithDatabase;
+import io.gingersnapproject.util.Utils;
+
+import io.quarkus.test.junit.QuarkusMock;
+import io.quarkus.test.junit.QuarkusTest;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@QuarkusTest
+@WithDatabase
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class HotRodServiceTest {
+
+   private final NotificationManager eventing = mock(NotificationManager.class);
+   private final Rule dummyRule = mock(Rule.class);
+
+   @Inject CacheService service;
+
+   @ConfigProperty(name = "gingersnap.cache.uri") URI hotRodURI;
+
+   @BeforeAll
+   public void beforeAll() {
+      QuarkusMock.installMockForType(eventing, NotificationManager.class);
+
+      when(dummyRule.valueColumns()).thenReturn(Optional.empty());
+      when(dummyRule.keyType()).thenReturn(KeyFormat.TEXT);
+      when(dummyRule.keyColumns()).thenReturn(List.of("id"));
+      when(dummyRule.plainSeparator()).thenReturn("|");
+   }
+
+   @BeforeEach
+   public void beforeEach() {
+      clearInvocations(eventing);
+      reset(eventing);
+      // Leak TCP connections.
+      ((Map<?, ?>) Utils.extractField(HotRodService.class, "managers", service)).clear();
+   }
+
+   @Test
+   public void testCacheReconnection() throws Exception {
+      var identifier = CacheIdentifier.of("rule", hotRodURI);
+
+      assertNotNull(service.start(identifier, dummyRule));
+
+      verify(eventing, times(1)).backendStartedEvent(eq(identifier), eq(false));
+
+      ConcurrentHashMap<URI, HotRodService.HotRodCache> managers = Utils.extractField(HotRodService.class, "managers", service);
+      assertTrue(managers.containsKey(identifier.uri()));
+      assertEquals(1, managers.size());
+
+      var manager = managers.get(identifier.uri());
+      assertTrue(manager.backends.containsKey(identifier.rule()));
+      assertEquals(1, manager.backends.size());
+
+      // We stop the cache.
+      service.stop(identifier);
+
+      verify(eventing, times(1)).backendStoppedEvent(eq(identifier));
+      assertFalse(manager.backends.get(identifier.rule()).isRunning());
+
+      // Cache manager stops asynchronously.
+      eventually(() -> "Cache manager didn't stop", () -> !manager.rcm.isStarted(), 10, TimeUnit.SECONDS);
+
+      // Now the cache restarts.
+      service.start(identifier, dummyRule);
+
+      verify(eventing, times(1)).backendStartedEvent(eq(identifier), eq(true));
+      verifyNoMoreInteractions(eventing);
+      assertTrue(manager.rcm.isStarted());
+      assertTrue(managers.get(identifier.uri()).backends.get(identifier.rule()).isRunning());
+   }
+
+   @Test
+   public void testMultiRulesSameURI() throws Exception {
+      var rule1 = CacheIdentifier.of("rule1", hotRodURI);
+      var rule2 = CacheIdentifier.of("rule2", hotRodURI);
+
+      var backend1 = service.start(rule1, dummyRule);
+      var backend2 = service.start(rule2, dummyRule);
+
+      assertNotSame(backend1, backend2);
+      assertTrue(backend1.isRunning());
+      assertTrue(backend2.isRunning());
+
+      verify(eventing, times(1)).backendStartedEvent(eq(rule1), eq(false));
+      verify(eventing, times(1)).backendStartedEvent(eq(rule2), eq(false));
+
+      ConcurrentHashMap<URI, HotRodService.HotRodCache> managers = Utils.extractField(HotRodService.class, "managers", service);
+      assertTrue(managers.containsKey(hotRodURI));
+      assertEquals(1, managers.size());
+
+      var manager = managers.get(hotRodURI);
+      assertTrue(manager.backends.containsKey(rule1.rule()));
+      assertTrue(manager.backends.containsKey(rule2.rule()));
+      assertEquals(2, manager.backends.size());
+
+      // Stopping rule2 still keep rule1.
+      service.stop(rule2);
+
+      verify(eventing, times(1)).backendStoppedEvent(eq(rule2));
+      assertTrue(manager.backends.get(rule1.rule()).isRunning());
+      assertFalse(manager.backends.get(rule2.rule()).isRunning());
+      assertTrue(manager.rcm.isStarted());
+
+      // Restarting rule2 does not affect rule1.
+      service.start(rule2, dummyRule);
+
+      verify(eventing, times(1)).backendStartedEvent(eq(rule2), eq(true));
+      verifyNoMoreInteractions(eventing);
+
+      manager = managers.get(hotRodURI);
+      assertTrue(manager.backends.get(rule1.rule()).isRunning());
+      assertTrue(manager.backends.get(rule2.rule()).isRunning());
+      assertNotSame(backend2, manager.backends.get(rule2.rule()));
+      assertSame(backend1, manager.backends.get(rule1.rule()));
+   }
+
+   @Test
+   public void testSameRuleDifferentURIs() throws Exception {
+      URI anotherURI = createAnotherHotRodURI();
+      var ruleA = CacheIdentifier.of("rule", hotRodURI);
+      var ruleB = CacheIdentifier.of("rule", anotherURI);
+
+      var backend1 = service.start(ruleA, dummyRule);
+      var backend2 = service.start(ruleB, dummyRule);
+
+      assertNotSame(backend1, backend2);
+      assertTrue(backend1.isRunning());
+      assertTrue(backend2.isRunning());
+
+      verify(eventing, times(1)).backendStartedEvent(eq(ruleA), eq(false));
+      verify(eventing, times(1)).backendStartedEvent(eq(ruleB), eq(false));
+
+      ConcurrentHashMap<URI, HotRodService.HotRodCache> managers = Utils.extractField(HotRodService.class, "managers", service);
+      assertTrue(managers.containsKey(hotRodURI));
+      assertTrue(managers.containsKey(anotherURI));
+      assertEquals(2, managers.size());
+
+      // Stopping one URI does not affect the other.
+      service.stop(ruleB);
+
+      verify(eventing, times(1)).backendStoppedEvent(eq(ruleB));
+
+      var managerA = managers.get(hotRodURI);
+      var managerB = managers.get(anotherURI);
+
+      assertTrue(managerA.rcm.isStarted());
+      eventually(() -> "Cache manager for another rule didn't stop", () -> !managerB.rcm.isStarted(), 10, TimeUnit.SECONDS);
+
+      // Restarting ruleB does not affect ruleA.
+      service.start(ruleB, dummyRule);
+
+      verify(eventing, times(1)).backendStartedEvent(eq(ruleB), eq(true));
+      verifyNoMoreInteractions(eventing);
+
+      assertSame(managerA, managers.get(hotRodURI));
+      assertNotSame(managerB, managers.get(anotherURI));
+
+      assertTrue(managerA.rcm.isStarted());
+      assertTrue(managers.get(anotherURI).rcm.isStarted());
+   }
+
+   private URI createAnotherHotRodURI() throws URISyntaxException {
+      return new URI("hotrod", hotRodURI.getUserInfo(), "127.0.0.1", hotRodURI.getPort(), hotRodURI.getPath(), hotRodURI.getQuery(), hotRodURI.getFragment());
+   }
+}

--- a/src/test/java/io/gingersnapproject/util/ByRef.java
+++ b/src/test/java/io/gingersnapproject/util/ByRef.java
@@ -1,0 +1,22 @@
+package io.gingersnapproject.util;
+
+public class ByRef<T> {
+
+   private volatile T ref;
+
+   public ByRef(T value) {
+      this.ref = value;
+   }
+
+   public ByRef() {
+      this(null);
+   }
+
+   public T ref() {
+      return ref;
+   }
+
+   public void setRef(T ref) {
+      this.ref = ref;
+   }
+}


### PR DESCRIPTION
* Identifying the current engines by the cache URI and rule name, creating N * M engines;
* When a new node joins, we create a new engine for each rule. When it leaves applies to all rules.
* Adding a new rule creates an engine for each known member. Removing a rule applies to all members.

I still need a way to write a proper test. Ideally, we would have some integration tests, especially the reconnection part.