### PR TITLE
Ignore method invocation of Profiles

### DIFF
--- a/src/test/java/io/gingersnapproject/testcontainers/Profiles.java
+++ b/src/test/java/io/gingersnapproject/testcontainers/Profiles.java
@@ -42,6 +42,10 @@ public class Profiles {
 
       @Override
       public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+         // We check only class level, to identify the `WithDatabase` annotation.
+         if (context.getTestMethod().isPresent())
+            return ConditionEvaluationResult.enabled("Do not verify for method, only class level");
+
          if (!ProfileManager.getLaunchMode().isDevOrTest())
             return ConditionEvaluationResult.disabled(String.format("No test running for '%s' mode!", ProfileManager.getLaunchMode()));
 


### PR DESCRIPTION
The verification at the method level causes it to skip. This whole time we were just skipping some tests :sweat_smile:. Thanks to Pedro for noticing it.