### PR TITLE
Fixing tests in main

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Requirements:
 2. Run `docker-compose -f deploy/oracle/oracle-compose.yaml up` to start Oracle Database exposed on 1521
     * This will create the database, user, schema, and tables necessary for testing.
 3. Run the cache-manager locally `docker run -it -p 11222:11222 -p 8080:8080 quay.io/gingersnap/cache-manager-oracle`
-4. Run `quarkus dev -Dquarkus.profile=oracle` from the poc base directory.
+4. Run `quarkus dev -Dquarkus.profile=oracle+dev` from the poc base directory.
     * This will run with the quarkus endpoint on 8080 and remote JVM debug on 5005.
 5. Perform inserts and updates to the database
     * Running `cat ./src/test/resources/oracle/populate.sql | docker exec -i <container id> sqlplus -S debezium/dbz@XEPDB1` will execute some operations in the database.

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -57,22 +57,22 @@ quarkus.package.type=uber-jar
 
 ## Now we have another rule using Oracle Database.
 ## This rule uses the oracle profile.
-%oracle.gingersnap.rule.us-east.connector.schema=DEBEZIUM
-%oracle.gingersnap.rule.us-east.connector.table=CUSTOMER
+%oracle+dev.gingersnap.rule.us-east.connector.schema=DEBEZIUM
+%oracle+dev.gingersnap.rule.us-east.connector.table=CUSTOMER
 
 # Debezium connection information
-%oracle.gingersnap.database.type=ORACLE
-%oracle.gingersnap.database.host=localhost
-%oracle.gingersnap.database.database=XE.XEPDB1
-%oracle.gingersnap.database.port=1521
-%oracle.gingersnap.database.username=debezium
-%oracle.gingersnap.database.password=dbz
+%oracle+dev.gingersnap.database.type=ORACLE
+%oracle+dev.gingersnap.database.host=localhost
+%oracle+dev.gingersnap.database.database=XE.XEPDB1
+%oracle+dev.gingersnap.database.port=1521
+%oracle+dev.gingersnap.database.username=debezium
+%oracle+dev.gingersnap.database.password=dbz
 
 # One cache backend for the rule
-%oracle.gingersnap.cache.uri=hotrod://127.0.0.1:11222
-%oracle.gingersnap.rule.us-east.key-columns=ID
-%oracle.gingersnap.rule.us-east.key-type=TEXT
-%oracle.gingersnap.rule.us-east.value-columns=ID,FULLNAME,EMAIL
+%oracle+dev.gingersnap.cache.uri=hotrod://127.0.0.1:11222
+%oracle+dev.gingersnap.rule.us-east.key-columns=ID
+%oracle+dev.gingersnap.rule.us-east.key-type=TEXT
+%oracle+dev.gingersnap.rule.us-east.value-columns=ID,FULLNAME,EMAIL
 
 %dev.quarkus.devservices.enabled=false
 

--- a/src/test/java/io/gingersnapproject/metrics/MetricsResourceTest.java
+++ b/src/test/java/io/gingersnapproject/metrics/MetricsResourceTest.java
@@ -70,7 +70,7 @@ public class MetricsResourceTest {
       if (hasRule) {
          name += "%s=\"%s\",".formatted(
                NAMING_CONVENTION.tagKey(RULE_KEY),
-               NAMING_CONVENTION.tagValue(RULE)
+               NAMING_CONVENTION.tagValue(RULE + "-localhost")
          );
       }
       name += "}";


### PR DESCRIPTION
* The metrics have the cache-manager pod address;
* The test uses the `oracle` profile, loading an additional rule from the `application.properties` file

And running to see how CI likes it.