### PR TITLE
Use 'eager-rule' property in default cache-manager rules

### DIFF
--- a/src/test/java/io/gingersnapproject/testcontainers/hotrod/CacheManagerContainer.java
+++ b/src/test/java/io/gingersnapproject/testcontainers/hotrod/CacheManagerContainer.java
@@ -50,9 +50,9 @@ public class CacheManagerContainer extends HotRodContainer<CacheManagerContainer
       if (rules != null) {
          for (String rule : rules) {
             // The where clause should use the same column the db-syncer uses.
-            withEnv(String.format("gingersnap_rule_%s_select_statement", rule), "select fullname, email from customer where fullname = ?");
-            withEnv(String.format("gingersnap_rule_%s_connector_schema", rule), "debezium");
-            withEnv(String.format("gingersnap_rule_%s_connector_table", rule), "customer");
+            withEnv(String.format("gingersnap_eager_rule_%s_select_statement", rule), "select fullname, email from customer where fullname = ?");
+            withEnv(String.format("gingersnap_eager_rule_%s_connector_schema", rule), "debezium");
+            withEnv(String.format("gingersnap_eager_rule_%s_connector_table", rule), "customer");
          }
       }
 


### PR DESCRIPTION
@jabolina @wburns The fact that the CI passes without these changes is worrying to me. I haven't looked into the details, but it makes me think that either we're not testing the db-syncer -> cache-manager interactions sufficiently, the errors are not being propagated or a combination of these :sweat_smile: 