### PR TITLE
Add E2E tests to Pull Requests

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -30,3 +30,10 @@ jobs:
         with:
           name: jdk17-test-results
           path: "**/target/*-reports*/**/TEST-*.xml"
+
+  e2e:
+    needs: jdk17
+    uses: gingersnap-project/e2e/.github/workflows/e2e.yaml@main
+    with:
+      db-syncer-ref: ${{ github.ref }}
+      db-syncer-repository: ${{ github.repository }}


### PR DESCRIPTION
This should result in the db-syncer image being created and then executed in the E2E testsuite with the most recent Operator code and cache-manager images.