### PR TITLE
Some changes in the test suite

### DIFF
--- a/src/test/java/io/gingersnapproject/cdc/ManagedEngineTest.java
+++ b/src/test/java/io/gingersnapproject/cdc/ManagedEngineTest.java
@@ -176,7 +176,6 @@ public class ManagedEngineTest {
          if (rule1Id.equals(entry.getKey())) {
             BooleanSupplier bs = () -> {
                ManagedEngine.Status s = Utils.extractField(ManagedEngine.StartStopEngine.class, "status", sse);
-               System.out.println(s);
                return s == ManagedEngine.Status.RETRYING;
             };
             eventually(() -> String.format("Engine '%s' did not enter into retry", entry.getKey()), bs, 10, TimeUnit.SECONDS);

--- a/src/test/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeClassCallback
+++ b/src/test/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeClassCallback
@@ -1,0 +1,1 @@
+io.gingersnapproject.testcontainers.BaseGingersnapResourceLifecycleManager


### PR DESCRIPTION
For other test runs, I identified that sometimes the rule registered automatically affects the tests. For example, failing to start the Debezium engine or something like that. So, I added a block working similarly to the `@BeforeAll` which will wait for 20 seconds until the engine starts _only for the rules added automatically.

Let me see if that helps in the CI.